### PR TITLE
Add escaping for '.' in profile keys.

### DIFF
--- a/src/Xhgui/Profiles.php
+++ b/src/Xhgui/Profiles.php
@@ -22,6 +22,9 @@ class Xhgui_Profiles
      */
     public function insert($profile)
     {
+    	// Mongo doesn't take kindly to dots hanging around keys
+	    // see http://php.net/manual/en/class.mongoexception.php
+		$profile = Xhgui_Util::escapeDotKeys($profile);
         return $this->_collection->insert($profile, array('w' => 0));
     }
 }

--- a/src/Xhgui/Util.php
+++ b/src/Xhgui/Util.php
@@ -20,4 +20,24 @@ class Xhgui_Util
         return preg_replace('/\=\d+/', '', $url);
     }
 
+	/**
+	 * Takes an array as input, replaces keys that contain '.' with $replacement
+	 * Non-recursive
+	 * Returns the modified array
+	 *
+	 * @param $array
+	 * @param string $replacement
+	 * @return array
+	 */
+	public static function escapeDotKeys($array, $replacement = '_dot_') {
+		$dotKeys = array_filter(array_keys($array), function ($key){
+			return strstr('.', $key );
+		});
+		foreach ($dotKeys as $dotKey){
+			$escapedKey = str_replace('.', $replacement, $dotKey);
+			$array[$escapedKey] = $array[$dotKey];
+			unset($array[$dotKey]);
+		}
+		return $array;
+    }
 }


### PR DESCRIPTION
Had an issue with MongoDB errors when trying to save profiling output.  
The cause seemed to be a key including a file name (dot), which Mongo does not tolerate.